### PR TITLE
fix: RMD start age 75 for birth year 1960+ per SECURE Act 2.0

### DIFF
--- a/src/retirement_model/constants.py
+++ b/src/retirement_model/constants.py
@@ -96,8 +96,10 @@ RMD_DIVISOR_TABLE = {
     120: 2.0,
 }
 
-# RMD start age per SECURE 2.0 Act
-RMD_START_AGE = 73
+# RMD start ages per SECURE 2.0 Act
+RMD_START_AGE = 73  # Birth years 1951-1959
+RMD_START_AGE_BORN_1960_PLUS = 75
+SECURE_ACT_BIRTH_YEAR_CUTOFF = 1960
 
 # Standard deduction (Married Filing Jointly, 2024)
 STANDARD_DEDUCTION_MFJ = 29200

--- a/src/retirement_model/simulation.py
+++ b/src/retirement_model/simulation.py
@@ -45,6 +45,7 @@ from retirement_model.taxes import (
     get_effective_tax_rate,
     get_marginal_tax_rate,
     inflate_brackets,
+    rmd_start_age_for_birth_year,
 )
 from retirement_model.withdrawals import (
     WithdrawalResult,
@@ -229,6 +230,12 @@ def run_simulation(
                 )
             )
 
+    # Compute per-person RMD start age from birth year (SECURE Act 2.0)
+    birth_year_primary = cfg.start_year - cfg.current_age_primary
+    birth_year_spouse = cfg.start_year - cfg.current_age_spouse
+    rmd_age_primary = rmd_start_age_for_birth_year(birth_year_primary)
+    rmd_age_spouse = rmd_start_age_for_birth_year(birth_year_spouse)
+
     # Track cumulative inflation for expense adjustments
     cumulative_inflation = 1.0
 
@@ -374,10 +381,10 @@ def run_simulation(
 
         # Mandatory RMDs (from ALL pretax-category accounts)
         pretax_bal_primary = get_total_balance_by_owner(accounts, TaxCategory.PRETAX, Owner.PRIMARY)
-        rmd_primary = calculate_rmd_amount(age_primary, pretax_bal_primary, cfg.rmd_start_age)
+        rmd_primary = calculate_rmd_amount(age_primary, pretax_bal_primary, rmd_age_primary)
 
         pretax_bal_spouse = get_total_balance_by_owner(accounts, TaxCategory.PRETAX, Owner.SPOUSE)
-        rmd_spouse = calculate_rmd_amount(age_spouse, pretax_bal_spouse, cfg.rmd_start_age)
+        rmd_spouse = calculate_rmd_amount(age_spouse, pretax_bal_spouse, rmd_age_spouse)
 
         total_rmd = rmd_primary + rmd_spouse
         rmd_withdrawn = 0.0

--- a/src/retirement_model/taxes.py
+++ b/src/retirement_model/taxes.py
@@ -9,6 +9,8 @@ from retirement_model.constants import (
     IRMAA_TIERS_MFJ,
     RMD_DIVISOR_TABLE,
     RMD_START_AGE,
+    RMD_START_AGE_BORN_1960_PLUS,
+    SECURE_ACT_BIRTH_YEAR_CUTOFF,
     STANDARD_DEDUCTION_MFJ,
     BracketDict,
 )
@@ -83,6 +85,13 @@ def calculate_capital_gains_tax(
         income_floor += taxable_in_bracket
 
     return tax
+
+
+def rmd_start_age_for_birth_year(birth_year: int) -> int:
+    """Return the RMD start age based on birth year per SECURE Act 2.0."""
+    if birth_year >= SECURE_ACT_BIRTH_YEAR_CUTOFF:
+        return RMD_START_AGE_BORN_1960_PLUS
+    return RMD_START_AGE
 
 
 def calculate_rmd_amount(age: int, balance: float, rmd_start_age: int = RMD_START_AGE) -> float:

--- a/tests/test_taxes.py
+++ b/tests/test_taxes.py
@@ -12,6 +12,7 @@ from retirement_model.taxes import (
     get_bracket_label,
     get_marginal_tax_rate,
     inflate_brackets,
+    rmd_start_age_for_birth_year,
 )
 
 
@@ -156,6 +157,20 @@ class TestCalculateRmdAmount:
     def test_custom_start_age(self):
         assert calculate_rmd_amount(72, 500000, rmd_start_age=72) > 0
         assert calculate_rmd_amount(71, 500000, rmd_start_age=72) == 0
+
+
+class TestRmdStartAgeForBirthYear:
+    def test_born_1959_gets_73(self):
+        assert rmd_start_age_for_birth_year(1959) == 73
+
+    def test_born_1960_gets_75(self):
+        assert rmd_start_age_for_birth_year(1960) == 75
+
+    def test_born_1965_gets_75(self):
+        assert rmd_start_age_for_birth_year(1965) == 75
+
+    def test_born_1951_gets_73(self):
+        assert rmd_start_age_for_birth_year(1951) == 73
 
 
 class TestCalculateIncomeTax:


### PR DESCRIPTION
Previously used a single rmd_start_age (73) for both spouses. Now computes per-person RMD start age from birth year:
- Born 1951-1959: age 73
- Born 1960+: age 75

Closes #9