### PR TITLE
feat: always show withdrawal strategy controls, remove collapsible

### DIFF
--- a/ui/src/lib/components/SimulateSettings.svelte
+++ b/ui/src/lib/components/SimulateSettings.svelte
@@ -53,24 +53,9 @@
       g.ceiling_percent = init > 0 ? ceiling / 100 / init : 1.2;
    }
 
-   function strategySummary(): string {
-      const c = portfolio.value.config;
-      const s = c.spending_strategy ?? 'fixed_dollar';
-      if (s === 'fixed_dollar') {
-         const spend =
-            c.annual_spend_net >= 1000
-               ? `$${Math.round(c.annual_spend_net / 1000)}K`
-               : `$${c.annual_spend_net}`;
-         return `Fixed ${spend}`;
-      }
-      if (s === 'percent_of_portfolio')
-         return `${toPct(c.withdrawal_rate ?? 0.04).toFixed(1)}% of Portfolio`;
-      if (s === 'guardrails' && c.guardrails_config) {
-         const adj = toPct(c.guardrails_config.adjustment_percent).toFixed(1);
-         return `Guardrails ${guardrailFloor()}-${guardrailCeiling()}% Adj ${adj}%`;
-      }
-      return 'RMD-Based';
-   }
+   let fixedDollarDiagnostic = $derived(
+      `Fixed ${currency(portfolio.value.config.annual_spend_net)}`,
+   );
 
    let strategyDiagnostic = $derived.by(() => {
       const c = portfolio.value.config;
@@ -122,8 +107,6 @@
          portfolio.value.config.strategy_target = 'standard';
       }
    });
-
-   let strategyOpen = $state(false);
 
    function handleKeydown(e: KeyboardEvent) {
       if (e.key === 'Enter') {
@@ -213,196 +196,141 @@
       {/if}
    </div>
 
-   <!-- Withdrawal Strategy: collapsible -->
-   <button
-      class="text-md text-surface-700 dark:text-surface-300 hover:text-surface-900 dark:hover:text-surface-100 cursor-pointer w-full text-left font-medium"
-      onclick={() => {
-         strategyOpen = !strategyOpen;
-      }}
-   >
-      {strategyOpen ? '▾' : '▸'} Withdrawal Strategy{#if !strategyOpen}
-         <span class="text-surface-500 font-normal">— {strategySummary()}</span
-         >{/if}
-   </button>
-
-   {#if strategyOpen}
-      <div class="pl-3 space-y-2">
-         {#if portfolio.value.config.spending_strategy === 'percent_of_portfolio'}
-            <div class="flex gap-4 flex-wrap items-end">
-               <label
-                  class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
-               >
-                  <span class="flex items-center gap-1"
-                     >Strategy <HelpButton
-                        topic="spending-strategies"
-                        anchor="strategy-selection"
-                     /></span
-                  >
-                  <select
-                     class="select w-44 text-sm"
-                     bind:value={portfolio.value.config.spending_strategy}
-                  >
-                     <option value="fixed_dollar">Fixed Dollar</option>
-                     <option value="percent_of_portfolio">% of Portfolio</option
-                     >
-                     <option value="guardrails">Guardrails</option>
-                  </select>
-               </label>
-               <label
-                  class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
-               >
-                  Withdrawal Rate
-                  <input
-                     type="number"
-                     class="input w-24 text-sm"
-                     value={toPct(
-                        portfolio.value.config.withdrawal_rate ?? 0.04,
-                     )}
-                     oninput={(e) =>
-                        setPct(
-                           e,
-                           (v) => (portfolio.value.config.withdrawal_rate = v),
-                        )}
-                     min="1"
-                     max="15"
-                     step="0.5"
-                  />
-               </label>
-            </div>
-         {:else if portfolio.value.config.spending_strategy === 'guardrails' && portfolio.value.config.guardrails_config}
-            <div class="flex gap-4 flex-wrap items-end">
-               <label
-                  class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
-               >
-                  <span class="flex items-center gap-1"
-                     >Strategy <HelpButton
-                        topic="spending-strategies"
-                        anchor="strategy-selection"
-                     /></span
-                  >
-                  <select
-                     class="select w-44 text-sm"
-                     bind:value={portfolio.value.config.spending_strategy}
-                  >
-                     <option value="fixed_dollar">Fixed Dollar</option>
-                     <option value="percent_of_portfolio">% of Portfolio</option
-                     >
-                     <option value="guardrails">Guardrails</option>
-                  </select>
-               </label>
-               <label
-                  class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
-               >
-                  <span class="flex items-center gap-1"
-                     >Floor Rate % <HelpButton
-                        topic="spending-strategies"
-                        anchor="guardrail-floor"
-                     /></span
-                  >
-                  <input
-                     type="number"
-                     class="input w-20 text-sm"
-                     value={guardrailFloor()}
-                     oninput={(e) =>
-                        setGuardrailRange(
-                           +(e.target as HTMLInputElement).value,
-                           guardrailCeiling(),
-                        )}
-                     min="1"
-                     max="10"
-                     step="0.5"
-                  />
-               </label>
-               <label
-                  class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
-               >
-                  <span class="flex items-center gap-1"
-                     >Ceiling Rate % <HelpButton
-                        topic="spending-strategies"
-                        anchor="guardrail-ceiling"
-                     /></span
-                  >
-                  <input
-                     type="number"
-                     class="input w-20 text-sm"
-                     value={guardrailCeiling()}
-                     oninput={(e) =>
-                        setGuardrailRange(
-                           guardrailFloor(),
-                           +(e.target as HTMLInputElement).value,
-                        )}
-                     min="2"
-                     max="15"
-                     step="0.5"
-                  />
-               </label>
-               <label
-                  class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
-               >
-                  Adjust %
-                  <input
-                     type="number"
-                     class="input w-20 text-sm"
-                     value={toPct(
-                        portfolio.value.config.guardrails_config
-                           .adjustment_percent,
-                     )}
-                     oninput={(e) =>
-                        setPct(
-                           e,
-                           (v) =>
-                              (portfolio.value.config.guardrails_config!.adjustment_percent =
-                                 v),
-                        )}
-                     min="1"
-                     max="25"
-                     step="0.5"
-                  />
-               </label>
-               <span class="text-xs text-surface-500 self-end pb-1.5"
-                  >Initial rate: {toPct(
-                     portfolio.value.config.guardrails_config
-                        .initial_withdrawal_rate,
-                  ).toFixed(1)}%</span
-               >
-            </div>
-         {:else}
-            <div class="flex gap-4 flex-wrap items-end">
-               <label
-                  class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
-               >
-                  <span class="flex items-center gap-1"
-                     >Strategy <HelpButton
-                        topic="spending-strategies"
-                        anchor="strategy-selection"
-                     /></span
-                  >
-                  <select
-                     class="select w-44 text-sm"
-                     bind:value={portfolio.value.config.spending_strategy}
-                  >
-                     <option value="fixed_dollar">Fixed Dollar</option>
-                     <option value="percent_of_portfolio">% of Portfolio</option
-                     >
-                     <option value="guardrails">Guardrails</option>
-                  </select>
-               </label>
-            </div>
-         {/if}
-         {#if strategyDiagnostic}
-            <div
-               class="text-xs {strategyDiagnostic.warn
-                  ? 'text-warning-600 dark:text-warning-400'
-                  : 'text-surface-500 dark:text-surface-400'}"
+   <!-- Withdrawal Strategy -->
+   <div class="space-y-2">
+      <div class="flex gap-4 flex-wrap items-end">
+         <label
+            class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
+         >
+            <span class="flex items-center gap-1"
+               >Strategy <HelpButton
+                  topic="spending-strategies"
+                  anchor="strategy-selection"
+               /></span
             >
-               {strategyDiagnostic.text}
-            </div>
-         {/if}
-         {#if showWithdrawalOrder}
-            <WithdrawalOrderEditor
-               bind:order={portfolio.value.config.withdrawal_order}
-            />
+            <select
+               class="select w-44 text-sm"
+               bind:value={portfolio.value.config.spending_strategy}
+            >
+               <option value="fixed_dollar">Fixed Dollar</option>
+               <option value="percent_of_portfolio">% of Portfolio</option>
+               <option value="guardrails">Guardrails</option>
+            </select>
+         </label>
+         {#if portfolio.value.config.spending_strategy === 'percent_of_portfolio'}
+            <label
+               class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
+            >
+               Withdrawal Rate
+               <input
+                  type="number"
+                  class="input w-24 text-sm"
+                  value={toPct(portfolio.value.config.withdrawal_rate ?? 0.04)}
+                  oninput={(e) =>
+                     setPct(
+                        e,
+                        (v) => (portfolio.value.config.withdrawal_rate = v),
+                     )}
+                  min="1"
+                  max="15"
+                  step="0.5"
+               />
+            </label>
+         {:else if portfolio.value.config.spending_strategy === 'guardrails' && portfolio.value.config.guardrails_config}
+            <label
+               class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
+            >
+               <span class="flex items-center gap-1"
+                  >Floor Rate % <HelpButton
+                     topic="spending-strategies"
+                     anchor="guardrail-floor"
+                  /></span
+               >
+               <input
+                  type="number"
+                  class="input w-20 text-sm"
+                  value={guardrailFloor()}
+                  oninput={(e) =>
+                     setGuardrailRange(
+                        +(e.target as HTMLInputElement).value,
+                        guardrailCeiling(),
+                     )}
+                  min="1"
+                  max="10"
+                  step="0.5"
+               />
+            </label>
+            <label
+               class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
+            >
+               <span class="flex items-center gap-1"
+                  >Ceiling Rate % <HelpButton
+                     topic="spending-strategies"
+                     anchor="guardrail-ceiling"
+                  /></span
+               >
+               <input
+                  type="number"
+                  class="input w-20 text-sm"
+                  value={guardrailCeiling()}
+                  oninput={(e) =>
+                     setGuardrailRange(
+                        guardrailFloor(),
+                        +(e.target as HTMLInputElement).value,
+                     )}
+                  min="2"
+                  max="15"
+                  step="0.5"
+               />
+            </label>
+            <label
+               class="flex flex-col gap-0.5 text-xs font-medium text-surface-600 dark:text-surface-400"
+            >
+               Adjust %
+               <input
+                  type="number"
+                  class="input w-20 text-sm"
+                  value={toPct(
+                     portfolio.value.config.guardrails_config
+                        .adjustment_percent,
+                  )}
+                  oninput={(e) =>
+                     setPct(
+                        e,
+                        (v) =>
+                           (portfolio.value.config.guardrails_config!.adjustment_percent =
+                              v),
+                     )}
+                  min="1"
+                  max="25"
+                  step="0.5"
+               />
+            </label>
+            <span class="text-xs text-surface-500 self-end pb-1.5"
+               >Initial rate: {toPct(
+                  portfolio.value.config.guardrails_config
+                     .initial_withdrawal_rate,
+               ).toFixed(1)}%</span
+            >
          {/if}
       </div>
-   {/if}
+      {#if portfolio.value.config.spending_strategy === 'fixed_dollar'}
+         <div class="text-xs text-surface-500 dark:text-surface-400">
+            {fixedDollarDiagnostic}
+         </div>
+      {:else if strategyDiagnostic}
+         <div
+            class="text-xs {strategyDiagnostic.warn
+               ? 'text-warning-600 dark:text-warning-400'
+               : 'text-surface-500 dark:text-surface-400'}"
+         >
+            {strategyDiagnostic.text}
+         </div>
+      {/if}
+      {#if showWithdrawalOrder}
+         <WithdrawalOrderEditor
+            bind:order={portfolio.value.config.withdrawal_order}
+         />
+      {/if}
+   </div>
 </div>

--- a/ui/src/lib/components/SimulateSettings.test.ts
+++ b/ui/src/lib/components/SimulateSettings.test.ts
@@ -33,26 +33,44 @@ describe('SimulateSettings', () => {
       expect(screen.getAllByText(/Conversion/).length).toBeGreaterThan(0);
    });
 
-   it('shows strategy summary when collapsed', () => {
+   it('shows strategy selector always visible', () => {
       renderSettings();
-      expect(screen.getByText(/Withdrawal Strategy/)).toBeInTheDocument();
+      expect(screen.getByText(/Strategy/)).toBeInTheDocument();
+      const selects = screen.getAllByRole('combobox');
+      const strategySelect = selects.find((s) =>
+         Array.from(s.querySelectorAll('option')).some(
+            (o) => o.value === 'fixed_dollar',
+         ),
+      );
+      expect(strategySelect).toBeInTheDocument();
    });
 
-   it('shows strategy controls after expanding strategy section', async () => {
+   it('shows fixed dollar diagnostic for fixed_dollar strategy', () => {
+      portfolio.value = {
+         ...portfolio.value,
+         config: {
+            ...portfolio.value.config,
+            spending_strategy: 'fixed_dollar',
+            annual_spend_net: 200000,
+         },
+      };
+      renderSettings();
+      expect(screen.getByText(/Fixed \$200,000/)).toBeInTheDocument();
+   });
+
+   it('shows guardrails controls without needing to expand', () => {
       portfolio.value = {
          ...portfolio.value,
          config: { ...portfolio.value.config, spending_strategy: 'guardrails' },
       };
       renderSettings();
-      const toggle = screen.getByText(/Withdrawal Strategy/);
-      await fireEvent.click(toggle);
       expect(screen.getByText(/Floor Rate %/)).toBeInTheDocument();
       expect(screen.getByText(/Ceiling Rate %/)).toBeInTheDocument();
       expect(screen.getByText('Adjust %')).toBeInTheDocument();
       expect(screen.getByText(/Initial rate:/)).toBeInTheDocument();
    });
 
-   it('shows withdrawal rate after expanding strategy for POP', async () => {
+   it('shows withdrawal rate for percent_of_portfolio without needing to expand', () => {
       portfolio.value = {
          ...portfolio.value,
          config: {
@@ -61,22 +79,7 @@ describe('SimulateSettings', () => {
          },
       };
       renderSettings();
-      const toggle = screen.getByText(/Withdrawal Strategy/);
-      await fireEvent.click(toggle);
       expect(screen.getByText('Withdrawal Rate')).toBeInTheDocument();
-   });
-
-   it('strategy section collapsed by default shows summary', () => {
-      portfolio.value = {
-         ...portfolio.value,
-         config: {
-            ...portfolio.value.config,
-            spending_strategy: 'fixed_dollar',
-            annual_spend_net: 140000,
-         },
-      };
-      renderSettings();
-      expect(screen.getByText(/Fixed \$140K/)).toBeInTheDocument();
    });
 
    it('does not show run mode radio buttons', () => {
@@ -102,8 +105,14 @@ describe('SimulateSettings', () => {
          },
       };
       renderSettings();
-      const select = screen.getByRole('combobox');
-      expect(select).not.toBeDisabled();
+      const selects = screen.getAllByRole('combobox');
+      const conversionSelect = selects.find((s) =>
+         Array.from(s.querySelectorAll('option')).some(
+            (o) => o.value === 'irmaa_tier_1',
+         ),
+      );
+      expect(conversionSelect).toBeDefined();
+      expect(conversionSelect).not.toBeDisabled();
    });
 
    it('shows inline error for inflation input when validation fails', () => {
@@ -134,7 +143,6 @@ describe('SimulateSettings', () => {
    it('shows conversion dropdown when pretax accounts exist', () => {
       renderSettings();
       expect(screen.getAllByText(/Conversion/).length).toBeGreaterThan(0);
-      expect(screen.getByRole('combobox')).toBeInTheDocument();
    });
 
    it('hides conversion dropdown when no pretax accounts', () => {
@@ -155,7 +163,13 @@ describe('SimulateSettings', () => {
          config: { ...portfolio.value.config, strategy_target: 'irmaa_tier_1' },
       };
       renderSettings();
-      expect(screen.getByRole('combobox')).toHaveValue('irmaa_tier_1');
+      const selects = screen.getAllByRole('combobox');
+      const conversionSelect = selects.find((s) =>
+         Array.from(s.querySelectorAll('option')).some(
+            (o) => o.value === 'irmaa_tier_1',
+         ),
+      );
+      expect(conversionSelect).toHaveValue('irmaa_tier_1');
 
       portfolio.value = {
          ...portfolio.value,


### PR DESCRIPTION
## Summary
- Remove collapsible toggle for withdrawal strategy — all params always visible
- Extract strategy dropdown to appear once (was duplicated 3x)
- Add "Fixed $X" diagnostic for fixed dollar strategy
- Keep rate-based diagnostic for % of Portfolio and Guardrails

Closes #16

## Test plan
- [ ] Strategy dropdown visible without clicking expand
- [ ] Fixed dollar shows budget amount diagnostic
- [ ] % of Portfolio shows withdrawal rate input + budget comparison
- [ ] Guardrails shows floor/ceiling/adjust inputs
- [ ] 543 frontend tests passing, lint clean

Generated with Claude Code
